### PR TITLE
fix: adjust modules registration sequence

### DIFF
--- a/internal/config/register.go
+++ b/internal/config/register.go
@@ -15,18 +15,18 @@ func Register() []Option {
 		Dependencies(
 			app.Providers(),
 		),
+		
+		/* Modules */
+		Modules(
+			srvhttp.HealthCheckModule{}, // health check module (http demo)
+			docs.Module{},
+		),
 
 		/* Module Constructors */
 		Constructors(
 			app.New,
 			config.New,          // config module
 			core.NewServeModule, // server module
-		),
-
-		/* Modules */
-		Modules(
-			srvhttp.HealthCheckModule{}, // health check module (http demo)
-			docs.Module{},
 		),
 	}
 }


### PR DESCRIPTION
Prior to the change, Healthcheck and docs modules are registered after the main app module. If the app takes up the root route ("/") in the router, the path for docs and healthchecks will never be reached.