### PR TITLE
chore: Docs module do not need docs folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ WORKDIR /root/
 
 # Copy the Pre-built binary file from the previous stage
 COPY config.example.yaml config.yaml
-COPY docs docs
 COPY --from=builder /go/bin/starter .
 
 EXPOSE 8080 9090


### PR DESCRIPTION
When `go:embed` is used, `go build` will package the original directory together